### PR TITLE
Split and rename pipeline steps

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/EntryPoint.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/EntryPoint.kt
@@ -3,7 +3,7 @@ package app.ehrenamtskarte.backend
 import app.ehrenamtskarte.backend.common.database.Database
 import app.ehrenamtskarte.backend.common.webservice.GraphQLHandler
 import app.ehrenamtskarte.backend.common.webservice.WebService
-import app.ehrenamtskarte.backend.stores.importer.DataImporter
+import app.ehrenamtskarte.backend.stores.importer.LbeDataImporter
 import com.expediagroup.graphql.extensions.print
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
@@ -28,7 +28,7 @@ class Entry : CliktCommand() {
             Database.setup(!production)
             if (importFlag) {
                 println("Importing data from Lbe")
-                if (!DataImporter.import(!production)) {
+                if (!LbeDataImporter.import(!production)) {
                     throw ProgramResult(statusCode = 5)
                 }
             } else {

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/constants.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/constants.kt
@@ -2,3 +2,7 @@ package app.ehrenamtskarte.backend.common
 
 const val COUNTRY_CODE = "de"
 const val STATE = "Bayern"
+
+// Postal code lookup and address sanitation fails/does not really make sense for a "Postfach"
+const val STREET_EXCLUDE_PATTERN = "Postfach"
+

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/DataImporter.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/DataImporter.kt
@@ -11,9 +11,9 @@ object DataImporter {
         val logger = LoggerFactory.getLogger(DataImporter::class.java)
         val pipe = {
             Unit.addStep(Download(logger, httpClient), logger) { logger.info("== Download raw data ==" )}
-                .addStep(PreSanitizeFilter(logger), logger) { logger.info("== Filter raw data ==") }
+                .addStep(FilterLbe(logger), logger) { logger.info("== Filter raw data ==") }
                 .addStep(Map(logger), logger) { logger.info("== Map raw to internal data ==") }
-                .addStep(Sanitize(logger, httpClient), logger) { logger.info("== Sanitize data ==") }
+                .addStep(SanitizeGeocode(logger, httpClient), logger) { logger.info("== Sanitize data ==") }
                 .addStep(PostSanitizeFilter(logger, httpClient), logger) { logger.info("== Filter sanitized data ==") }
                 .addStep(Encode(logger), logger) { logger.info("== Handle encoding issues ==") }
                 .addStep(Store(logger, manualImport), logger) { logger.info("== Store remaining data to db ==") }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/LbeDataImporter.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/LbeDataImporter.kt
@@ -12,8 +12,9 @@ object LbeDataImporter {
         val pipe = {
             Unit.addStep(DownloadLbe(logger, httpClient), logger) { logger.info("== Download lbe data ==" )}
                 .addStep(FilterLbe(logger), logger) { logger.info("== Filter lbe data ==") }
-                .addStep(Map(logger), logger) { logger.info("== Map raw to internal data ==") }
-                .addStep(SanitizeGeocode(logger, httpClient), logger) { logger.info("== Sanitize data ==") }
+                .addStep(MapFromLbe(logger), logger) { logger.info("== Map lbe to internal data ==") }
+                .addStep(SanitizeAddress(logger), logger) { logger.info("== Sanitize address ==") }
+                .addStep(SanitizeGeocode(logger, httpClient), logger) { logger.info("== Sanitize data with geocoding ==") }
                 .addStep(PostSanitizeFilter(logger, httpClient), logger) { logger.info("== Filter sanitized data ==") }
                 .addStep(Encode(logger), logger) { logger.info("== Handle encoding issues ==") }
                 .addStep(Store(logger, manualImport), logger) { logger.info("== Store remaining data to db ==") }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/LbeDataImporter.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/LbeDataImporter.kt
@@ -4,14 +4,14 @@ import app.ehrenamtskarte.backend.stores.importer.steps.*
 import io.ktor.client.HttpClient
 import org.slf4j.LoggerFactory
 
-object DataImporter {
+object LbeDataImporter {
     private val httpClient = HttpClient()
 
     fun import(manualImport: Boolean): Boolean {
-        val logger = LoggerFactory.getLogger(DataImporter::class.java)
+        val logger = LoggerFactory.getLogger(LbeDataImporter::class.java)
         val pipe = {
-            Unit.addStep(Download(logger, httpClient), logger) { logger.info("== Download raw data ==" )}
-                .addStep(FilterLbe(logger), logger) { logger.info("== Filter raw data ==") }
+            Unit.addStep(DownloadLbe(logger, httpClient), logger) { logger.info("== Download lbe data ==" )}
+                .addStep(FilterLbe(logger), logger) { logger.info("== Filter lbe data ==") }
                 .addStep(Map(logger), logger) { logger.info("== Map raw to internal data ==") }
                 .addStep(SanitizeGeocode(logger, httpClient), logger) { logger.info("== Sanitize data ==") }
                 .addStep(PostSanitizeFilter(logger, httpClient), logger) { logger.info("== Filter sanitized data ==") }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/DownloadLbe.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/DownloadLbe.kt
@@ -13,7 +13,7 @@ import io.ktor.http.HttpMethod
 import kotlinx.coroutines.runBlocking
 import org.slf4j.Logger
 
-class Download(private val logger: Logger, private val httpClient: HttpClient) : PipelineStep<Unit, List<LbeAcceptingStore>>() {
+class DownloadLbe(private val logger: Logger, private val httpClient: HttpClient) : PipelineStep<Unit, List<LbeAcceptingStore>>() {
 
     override fun execute(input: Unit): List<LbeAcceptingStore> {
         try {

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/FilterLbe.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/FilterLbe.kt
@@ -5,7 +5,7 @@ import app.ehrenamtskarte.backend.stores.importer.matchesNa
 import app.ehrenamtskarte.backend.stores.importer.types.LbeAcceptingStore
 import org.slf4j.Logger
 
-class PreSanitizeFilter(private val logger: Logger): PipelineStep<List<LbeAcceptingStore>, List<LbeAcceptingStore>>() {
+class FilterLbe(private val logger: Logger): PipelineStep<List<LbeAcceptingStore>, List<LbeAcceptingStore>>() {
     private val invalidLocations = arrayOf("Musterhausen")
 
     override fun execute(input: List<LbeAcceptingStore>): List<LbeAcceptingStore> = input.filter { filterLbe(it) }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/MapFromLbe.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/MapFromLbe.kt
@@ -1,0 +1,54 @@
+package app.ehrenamtskarte.backend.stores.importer.steps
+
+import app.ehrenamtskarte.backend.common.COUNTRY_CODE
+import app.ehrenamtskarte.backend.stores.importer.PipelineStep
+import app.ehrenamtskarte.backend.stores.importer.replaceNa
+import app.ehrenamtskarte.backend.stores.importer.types.AcceptingStore
+import app.ehrenamtskarte.backend.stores.importer.types.LbeAcceptingStore
+import org.slf4j.Logger
+
+const val MISCELLANEOUS_CATEGORY = 9
+const val ALTERNATIVE_MISCELLANEOUS_CATEGORY = 99
+
+class MapFromLbe(private val logger: Logger) : PipelineStep<List<LbeAcceptingStore>, List<AcceptingStore>>() {
+    override fun execute(input: List<LbeAcceptingStore>) = input.mapNotNull {
+        try {
+            AcceptingStore(
+                it.name.clean()!!,
+                COUNTRY_CODE,
+                it.location.clean()!!,
+                it.postalCode.clean(),
+                it.street.clean(),
+                it.houseNumber.clean(),
+                null,
+                it.longitude.safeToDouble(),
+                it.latitude.safeToDouble(),
+                categoryId(it.category!!),
+                it.email.clean(),
+                it.telephone.clean(),
+                it.homepage.clean(),
+                it.discount.clean(false)
+            )
+        } catch (e: Exception) {
+            logger.info("Exception occurred while mapping $it", e)
+            null
+        }
+    }
+
+    private fun String?.safeToDouble(): Double? {
+        return this?.clean()?.replace(",", ".")?.toDouble()
+    }
+
+    private fun categoryId(category: String): Int {
+        val int = category.toInt()
+        return if (int == ALTERNATIVE_MISCELLANEOUS_CATEGORY) MISCELLANEOUS_CATEGORY else int
+    }
+
+    private fun String?.clean(removeSubsequentWhitespaces: Boolean = true): String? {
+        val trimmed = this?.replaceNa()?.trim()
+        if (removeSubsequentWhitespaces) {
+            return trimmed?.replace(Regex("""\s{2,}"""), " ")
+        }
+        return trimmed
+    }
+}

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/SanitizeAddress.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/SanitizeAddress.kt
@@ -15,7 +15,7 @@ class SanitizeAddress(private val logger: Logger) : PipelineStep<List<AcceptingS
         try {
             if (it.street?.contains(STREET_EXCLUDE_PATTERN) == true) return@mapNotNull it
 
-            it.sanitizeStreetHouseNumber().sanitizePostalCode()
+            it.sanitizePostalCode().sanitizeStreetHouseNumber()
         } catch (e: Exception) {
             logger.info("Exception occurred while sanitizing the address of $it", e)
             null
@@ -65,7 +65,7 @@ class SanitizeAddress(private val logger: Logger) : PipelineStep<List<AcceptingS
                 if (res != cleanHouseNumber) res else null
             } else null
 
-            val newAddress = listOfNotNull(cleanStreet, cleanHouseNumber, residue).joinToString("|")
+            val newAddress = listOfNotNull(cleanStreet, cleanHouseNumber, residue).filterNot { it.isEmpty() }.joinToString("|")
             logger.logChange("$name, $location", "Address", "$street|$houseNumber", newAddress)
 
             return copy(street = cleanStreet, houseNumber = cleanHouseNumber, additionalAddressInformation = residue)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/SanitizeAddress.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/SanitizeAddress.kt
@@ -1,5 +1,6 @@
 package app.ehrenamtskarte.backend.stores.importer.steps
 
+import app.ehrenamtskarte.backend.common.STREET_EXCLUDE_PATTERN
 import app.ehrenamtskarte.backend.stores.importer.PipelineStep
 import app.ehrenamtskarte.backend.stores.importer.logChange
 import app.ehrenamtskarte.backend.stores.importer.types.AcceptingStore
@@ -12,6 +13,8 @@ class SanitizeAddress(private val logger: Logger) : PipelineStep<List<AcceptingS
 
     override fun execute(input: List<AcceptingStore>) = input.mapNotNull {
         try {
+            if (it.street?.contains(STREET_EXCLUDE_PATTERN) == true) return@mapNotNull it
+
             it.sanitizeStreetHouseNumber().sanitizePostalCode()
         } catch (e: Exception) {
             logger.info("Exception occurred while sanitizing the address of $it", e)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/SanitizeAddress.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/SanitizeAddress.kt
@@ -1,40 +1,20 @@
 package app.ehrenamtskarte.backend.stores.importer.steps
 
-import app.ehrenamtskarte.backend.common.COUNTRY_CODE
 import app.ehrenamtskarte.backend.stores.importer.PipelineStep
 import app.ehrenamtskarte.backend.stores.importer.logChange
-import app.ehrenamtskarte.backend.stores.importer.replaceNa
 import app.ehrenamtskarte.backend.stores.importer.types.AcceptingStore
-import app.ehrenamtskarte.backend.stores.importer.types.LbeAcceptingStore
 import org.intellij.lang.annotations.Language
 import org.slf4j.Logger
 
-const val MISCELLANEOUS_CATEGORY = 9
-const val ALTERNATIVE_MISCELLANEOUS_CATEGORY = 99
-
-class Map(private val logger: Logger) : PipelineStep<List<LbeAcceptingStore>, List<AcceptingStore>>() {
+class SanitizeAddress(private val logger: Logger) : PipelineStep<List<AcceptingStore>, List<AcceptingStore>>() {
     private val houseNumberRegex = houseNumberRegex()
+    private val postalCodeRegex = Regex("""[0-9]{5}""")
 
-    override fun execute(input: List<LbeAcceptingStore>) = input.mapNotNull {
+    override fun execute(input: List<AcceptingStore>) = input.mapNotNull {
         try {
-            AcceptingStore(
-                it.name.clean()!!,
-                COUNTRY_CODE,
-                it.location.clean()!!,
-                it.cleanPostalCode(),
-                it.street.clean(),
-                it.houseNumber.clean(),
-                null,
-                it.longitude.safeToDouble(),
-                it.latitude.safeToDouble(),
-                categoryId(it.category!!),
-                it.email.clean(),
-                it.telephone.clean(),
-                it.homepage.clean(),
-                it.discount.clean(false)
-            ).sanitizeStreetHouseNumber()
+            it.sanitizeStreetHouseNumber().sanitizePostalCode()
         } catch (e: Exception) {
-            logger.info("Exception occurred while mapping $it", e)
+            logger.info("Exception occurred while sanitizing the address of $it", e)
             null
         }
     }
@@ -78,7 +58,7 @@ class Map(private val logger: Logger) : PipelineStep<List<LbeAcceptingStore>, Li
 
             // Residue that is neither the street nor the house number, e.g. "im Hauptbahnhof", "Ecke Theaterstraße"
             val residue = if (houseNumberMatch.range.last < address.length - 1) {
-                val res = address.substring(houseNumberMatch.range.last + 1).trim { !it.isLetterOrDigit() }.clean()
+                val res = address.substring(houseNumberMatch.range.last + 1).trim { !it.isLetterOrDigit() }
                 if (res != cleanHouseNumber) res else null
             } else null
 
@@ -90,32 +70,14 @@ class Map(private val logger: Logger) : PipelineStep<List<LbeAcceptingStore>, Li
         return this
     }
 
-    private fun String?.safeToDouble(): Double? {
-        return this?.clean()?.replace(",", ".")?.toDouble()
-    }
+    private fun AcceptingStore.sanitizePostalCode(): AcceptingStore {
+        val oldPostalCode = postalCode ?: return this
 
-    private fun categoryId(category: String): Int {
-        val int = category.toInt()
-        return if (int == ALTERNATIVE_MISCELLANEOUS_CATEGORY) MISCELLANEOUS_CATEGORY else int
-    }
-
-    private fun String?.clean(removeSubsequentWhitespaces: Boolean = true): String? {
-        val trimmed = this?.replaceNa()?.trim()
-        if (removeSubsequentWhitespaces) {
-            return trimmed?.replace(Regex("""\s{2,}"""), " ")
-        }
-        return trimmed
-    }
-
-    private fun LbeAcceptingStore.cleanPostalCode(): String? {
-        val oldPostalCode = postalCode ?: return null
-        val fiveDigitRegex = Regex("""[0-9]{5}""")
-
-        val newPostalCode = fiveDigitRegex.find(oldPostalCode)?.value
-        if (newPostalCode != oldPostalCode.clean()) {
+        val newPostalCode = postalCodeRegex.find(oldPostalCode)?.value
+        if (newPostalCode != oldPostalCode) {
             logger.logChange("$name, $location", "Postal code", oldPostalCode, newPostalCode)
         }
-        return newPostalCode
+        return copy(postalCode = newPostalCode)
     }
 
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/SanitizeGeocode.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/SanitizeGeocode.kt
@@ -1,5 +1,6 @@
 package app.ehrenamtskarte.backend.stores.importer.steps
 
+import app.ehrenamtskarte.backend.common.STREET_EXCLUDE_PATTERN
 import app.ehrenamtskarte.backend.stores.geocoding.FeatureFetcher
 import app.ehrenamtskarte.backend.stores.geocoding.isCloseToBoundingBox
 import app.ehrenamtskarte.backend.stores.geocoding.isInBoundingBox
@@ -11,9 +12,6 @@ import kotlinx.coroutines.runBlocking
 import org.geojson.Feature
 import org.geojson.Point
 import org.slf4j.Logger
-
-// Postal code lookup fails/does not really make sense for a "Postfach"
-const val STREET_EXCLUDE_PATTERN = "Postfach"
 
 class SanitizeGeocode(private val logger: Logger, httpClient: HttpClient) : PipelineStep<List<AcceptingStore>, List<AcceptingStore>>() {
     private val featureFetcher = FeatureFetcher(httpClient)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/SanitizeGeocode.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/importer/steps/SanitizeGeocode.kt
@@ -15,7 +15,7 @@ import org.slf4j.Logger
 // Postal code lookup fails/does not really make sense for a "Postfach"
 const val STREET_EXCLUDE_PATTERN = "Postfach"
 
-class Sanitize(private val logger: Logger, httpClient: HttpClient) : PipelineStep<List<AcceptingStore>, List<AcceptingStore>>() {
+class SanitizeGeocode(private val logger: Logger, httpClient: HttpClient) : PipelineStep<List<AcceptingStore>, List<AcceptingStore>>() {
     private val featureFetcher = FeatureFetcher(httpClient)
 
     override fun execute(input: List<AcceptingStore>): List<AcceptingStore> = runBlocking {


### PR DESCRIPTION
Follow up on #468. Renames pipeline steps to include `Lbe` and splits the `Map` step into `MapFromLbe` and `SanitizeAddress`.