### PR TITLE
Text selector not visible

### DIFF
--- a/frontend/lib/themes.dart
+++ b/frontend/lib/themes.dart
@@ -17,6 +17,10 @@ ThemeData get lightTheme {
     ),
   );
   return lightTheme.copyWith(
+    textSelectionTheme: const TextSelectionThemeData(
+      selectionHandleColor: Colors.white,
+      selectionColor: Color(0xFF505050),
+    ),
     appBarTheme: AppBarTheme(
       systemOverlayStyle: SystemUiOverlayStyle.light,
       color: lightTheme.colorScheme.primary,
@@ -40,6 +44,10 @@ ThemeData get darkTheme {
     ),
   );
   return theme.copyWith(
+    textSelectionTheme: const TextSelectionThemeData(
+      selectionHandleColor: Colors.white,
+      selectionColor: Color(0xFF505050),
+    ),
     appBarTheme: AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.light, color: theme.colorScheme.primary),
   );
 }


### PR DESCRIPTION
Fixes #438 

![signal-2022-02-13-113626](https://user-images.githubusercontent.com/29095487/153749321-58c67842-ba65-4a16-ac2b-9177fb5e1424.png)
![signal-2022-02-13-113847](https://user-images.githubusercontent.com/29095487/153749361-e4a27ae4-5396-4f6e-bc6f-937ae9272026.png)
<img width="379" alt="Screenshot 2022-02-13 at 15 00 27" src="https://user-images.githubusercontent.com/29095487/153756654-329a2dba-f39a-4701-9cd5-f3f3a91377bf.png">


Wasn't sure about a good highlight color to use so I just picked one already used.
